### PR TITLE
Fix Issue #7 (Drop attribution)

### DIFF
--- a/ebooks.py
+++ b/ebooks.py
@@ -120,6 +120,19 @@ if __name__=="__main__":
                 print "ALL THE THINGS"
                 ebook_tweet = ebook_tweet.upper()
 
+        # strip out any via @handle or says @handle
+        # via or says should always be second to last word, let's grab that
+        # TODO: this only works if another tweet doesn't get added
+        # solution: run this check before and after length addition
+        last_space = ebook_tweet.rindex(' ')
+        previous_space = ebook_tweet.rindex(' ', 0, last_space)
+        second_last_word = ebook_tweet[previous_space+1:last_space].lower()
+
+        if second_last_word == 'via' or second_last_word == 'says':
+            # strip the credit
+            ebook_tweet = ebook_tweet[:previous_space]
+
+
         #throw out tweets that match anything from the source account.
         if ebook_tweet != None and len(ebook_tweet) < 110:
             for tweet in source_tweets:

--- a/ebooks.py
+++ b/ebooks.py
@@ -55,6 +55,23 @@ def grab_tweets(api, max_id=None):
             source_tweets.append(tweet.text)
     return source_tweets, max_id
 
+def remove_credit(ebook_tweet):
+    # strip out any via @handle or says @handle
+    # via or says should always be second to last word, let's grab that
+    last_space = ebook_tweet.rindex(' ')
+    try:
+        previous_space = ebook_tweet.rindex(' ', 0, last_space)
+    except ValueError:
+        # two-word tweet? nothing to do!
+        return ebook_tweet
+    # get the second-last word from the space indexes
+    second_last_word = ebook_tweet[previous_space+1:last_space].lower()
+
+    if second_last_word == 'via' or second_last_word == 'says':
+        # strip the credit
+        ebook_tweet = ebook_tweet[:previous_space]
+    return ebook_tweet
+
 if __name__=="__main__":
     order = ORDER
     if DEBUG==False:
@@ -104,6 +121,8 @@ if __name__=="__main__":
            print "Losing last word randomly"
            ebook_tweet = re.sub(r'\s\w+.$','',ebook_tweet) 
            print ebook_tweet
+        # remove any RT credis
+        ebook_tweet = remove_credit(ebook_tweet)
     
         #if a tweet is very short, this will randomly add a second sentence to it.
         if ebook_tweet != None and len(ebook_tweet) < 40:
@@ -119,19 +138,8 @@ if __name__=="__main__":
                 #say something crazy/prophetic in all caps
                 print "ALL THE THINGS"
                 ebook_tweet = ebook_tweet.upper()
-
-        # strip out any via @handle or says @handle
-        # via or says should always be second to last word, let's grab that
-        # TODO: this only works if another tweet doesn't get added
-        # solution: run this check before and after length addition
-        last_space = ebook_tweet.rindex(' ')
-        previous_space = ebook_tweet.rindex(' ', 0, last_space)
-        second_last_word = ebook_tweet[previous_space+1:last_space].lower()
-
-        if second_last_word == 'via' or second_last_word == 'says':
-            # strip the credit
-            ebook_tweet = ebook_tweet[:previous_space]
-
+            # remove RT credit again, it may have gotten re-added
+            ebook_tweet = remove_credit(ebook_tweet)
 
         #throw out tweets that match anything from the source account.
         if ebook_tweet != None and len(ebook_tweet) < 110:


### PR DESCRIPTION
Hey! This is a pull request to fix issue #7 (Drop Attribution?)
The code adds another function remove_credit which takes the text of the ebook tweet and searches it to see if the second-to-last word is 'via' or 'says'. If so, it removes that and anything after. The logic here being that 'via' or 'says' style RTs will always have 'via' or 'says' as their second to last word (the last word being the username)

The function gets called twice, once after the initial ebook_tweet is generated and once again if the tweet is determined to be too short and additional text is added. This is so that if the first tweet had a 'via' credit, it still gets removed, along with the second tweet's 'via' credit (if any.)

This is my first real PR, so I welcome feedback / improvements / whatever else. Thanks!