### PR TITLE
Add SOURCE_EXCLUDE setting to filter the source account's tweets

### DIFF
--- a/ebooks.py
+++ b/ebooks.py
@@ -52,6 +52,8 @@ def grab_tweets(api, max_id=None):
     max_id = user_tweets[len(user_tweets)-1].id-1
     for tweet in user_tweets:
         tweet.text = filter_tweet(tweet)
+        if re.search(SOURCE_EXCLUDE, tweet.text):
+            continue
         if len(tweet.text) != 0:
             source_tweets.append(tweet.text)
     return source_tweets, max_id

--- a/local_settings_example.py
+++ b/local_settings_example.py
@@ -11,6 +11,7 @@ MY_ACCESS_TOKEN_SECRET = 'Your Access Token Secret'
 SOURCE_ACCOUNTS = [""] #A list of comma-separated, quote-enclosed Twitter handles of account that you'll generate tweets based on. It should look like ["account1", "account2"]. If you want just one account, no comma needed.
 ODDS = 8 #How often do you want this to run? 1/8 times?
 ORDER = 2 #how closely do you want this to hew to sensical? 1 is low and 3 is high.
+SOURCE_EXCLUDE = r'^$' #Source tweets that match this regexp will not be added to the Markov chain. You might want to filter out inappropriate words for example.
 DEBUG = True #Set this to False to start Tweeting live
 STATIC_TEST = False #Set this to True if you want to test Markov generation from a static file instead of the API.
 TEST_SOURCE = ".txt" #The name of a text file of a string-ified list for testing. To avoid unnecessarily hitting Twitter API. You can use the included testcorpus.txt, if needed.


### PR DESCRIPTION
`SOURCE_EXCLUDE` is a regular expression - any tweets from the source account that match it will not be passed on to the Markov generation and so will not be used to produce the bot's tweets. My intention behind this feature is to prevent your bot from "learning" inappropriate words or phrases, thereby producing inappropriate tweets.