### PR TITLE
Coerce my_range to integer

### DIFF
--- a/ebooks.py
+++ b/ebooks.py
@@ -87,7 +87,7 @@ if __name__=="__main__":
                 status_count = handle_stats.statuses_count
                 max_id=None
                 if status_count<3200:
-                    my_range = (status_count/200) + 1
+                    my_range = int((status_count/200) + 1)
                 else:
                     my_range = 17
                 for x in range(my_range)[1:]:


### PR DESCRIPTION
Because of float division in Python 3, this was erroring-out at line 93.